### PR TITLE
add streaming to script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 /postgres-data
 /redis-data
 /db
-/backfill.log
+*.log
 /.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
           memory: 16384MB
     networks:
       - index-network
+
   index-redis:
     image: 'redis:7.2-alpine'
     restart: unless-stopped
@@ -47,6 +48,7 @@ services:
           memory: 16384MB
     networks:
       - index-network
+      
   index-app:
     build:
       context: .

--- a/start.sh
+++ b/start.sh
@@ -1,50 +1,37 @@
 #!/bin/bash
 
-# Function to start the process
-start_process() {
-    nohup yarn run backfill > backfill.log 2>&1 &
+# Flag file to check if backfill has already been completed
+BACKFILL_FLAG="/tmp/backfill_done"
+
+# Function to start the initial backfill if not already done
+initial_backfill() {
+    if [ ! -f "$BACKFILL_FLAG" ]; then
+        echo "Starting initial backfill..."
+        nohup yarn run backfill > backfill.log 2>&1 &
+
+        # Wait for the backfill process to complete 
+        while [ ! -f "$BACKFILL_FLAG" ]; do
+            echo "Waiting for backfill to complete..."
+            sleep 10  # Poll every 10 seconds
+        done
+
+        echo "Backfill completed successfully."
+        start_streaming  # Start streaming 
+    else
+        echo "Backfill already completed. Proceeding to start streaming."
+        start_streaming
+    fi
+}
+
+# Function to start the streaming process
+start_streaming() {
+    nohup yarn start > streaming.log 2>&1 &
     sleep 10
     pids=$(pgrep -f node)
     if [ -n "$pids" ]; then
-        echo "Process started with PID(s): $pids"
+        echo "Streaming process started with PID(s): $pids"
     else
-        echo "Failed to start the process."
-    fi
-}
-
-# Function to kill all Node.js processes started by start_process
-kill_process() {
-    if [ -n "$pids" ]; then
-        echo "Killing Node.js process(es): $pids"
-        for pid in $pids; do
-            if kill -0 "$pid" 2>/dev/null; then
-                kill -9 "$pid"
-                echo "Process $pid killed."
-            else
-                echo "Process $pid was already terminated."
-            fi
-        done
-    else
-        echo "No Node.js processes found."
-    fi
-}
-
-# Function to check if each stored PID is running
-check_process() {
-    all_running=true
-    for pid in $pids; do
-        if ! kill -0 "$pid" 2>/dev/null; then
-            echo "Process $pid is not running."
-            all_running=false
-        fi
-    done
-
-    if $all_running; then
-        echo "All processes are running: $pids"
-        return 0
-    else
-        echo "Some processes are not running."
-        return 1
+        echo "Failed to start the streaming process."
     fi
 }
 
@@ -52,15 +39,15 @@ check_process() {
 yarn
 yarn kysely:migrate
 
-# Start the process initially
-start_process
+# Start the initial backfill or streaming based on the flag
+initial_backfill
 
-# Monitor the process
+# Monitor the process and restart if necessary
 while true; do
     sleep 60  # Check every 60 seconds
     if ! check_process; then
         echo "Restarting process..."
         kill_process
-        start_process
+        start_streaming  # Only restart streaming after backfill has been completed
     fi
 done


### PR DESCRIPTION
Update the `start.sh` script to reflect the separation of streaming and backfilling processes. Currently, backfilling is always called, even if it has already been completed. The changes will ensure that backfilling runs only once and that streaming starts immediately after backfilling finishes. There may be some redundancy, as backfilling tracks events right after it completes, meaning that the `start_streaming` call might not be necessary (will check back on this later).